### PR TITLE
Feature/insert staff

### DIFF
--- a/include/vrv/editortoolkit.h
+++ b/include/vrv/editortoolkit.h
@@ -40,7 +40,7 @@ public:
     bool Drag(std::string elementId, int x, int y);
     bool Insert(std::string elementType, std::string startId, std::string endId);
     bool Insert(std::string elementType, std::string staffId, int ulx, int uly,
-        std::vector<std::pair<std::string, std::string>> attributes);
+        int lrx, int lry, std::vector<std::pair<std::string, std::string>> attributes);
     bool Set(std::string elementId, std::string attrType, std::string attrValue);
     bool Remove(std::string elementId);
     ///@}
@@ -62,7 +62,7 @@ protected:
     bool ParseDragAction(jsonxx::Object param, std::string *elementId, int *x, int *y);
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *startId, std::string *endId);
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *staffId, int *ulx, int *uly,
-        std::vector<std::pair<std::string, std::string>> *attributes);
+        int *lrx, int *lry, std::vector<std::pair<std::string, std::string>> *attributes);
     bool ParseSetAction(jsonxx::Object param, std::string *elementId, std::string *attrType, std::string *attrValue);
     bool ParseRemoveAction(jsonxx::Object param, std::string *elementId);
     ///@}

--- a/include/vrv/editortoolkit.h
+++ b/include/vrv/editortoolkit.h
@@ -74,7 +74,7 @@ protected:
 };
 
 //--------------------------------------------------------------------------------
-// ClosestBB Comparator struct
+// Comparator structs
 //--------------------------------------------------------------------------------
 // To be used with std::sort to find the object with a closest bounding
 // box to a point defined by the x and y parameters of ClosestBB
@@ -105,6 +105,28 @@ struct ClosestBB {
         int distA = distanceToBB(zoneA->GetUlx(), zoneA->GetUly(), zoneA->GetLrx(), zoneA->GetLry());
         int distB = distanceToBB(zoneB->GetUlx(), zoneB->GetUly(), zoneB->GetLrx(), zoneB->GetLry());
         return (distA < distB);
+    }
+};
+
+// To be used with std::stable_sort to find the position to insert a new staff
+
+struct StaffSort {
+    // Sort staves left-to-right and top-to-bottom
+    // Sort by y if there is no intersection, by x if there is
+    bool operator() (Object *a, Object *b) {
+        if (!a->GetFacsimileInterface() || !b->GetFacsimileInterface()) return true;
+        Zone *zoneA = a->GetFacsimileInterface()->GetZone();
+        Zone *zoneB = b->GetFacsimileInterface()->GetZone();
+
+        // Check for y intersection
+        if ((zoneA->GetUly() < zoneB->GetLry() && zoneA->GetLry() > zoneB->GetLry()) ||
+            (zoneA->GetUly() < zoneB->GetUly() && zoneA->GetLry() > zoneB->GetUly())) {
+            // y intersection, so sort by ulx
+            return (zoneA->GetUlx() < zoneB->GetUlx());
+        }
+        else { // no intersection
+            return (zoneA->GetUly() < zoneB->GetUly());
+        }
     }
 };
 

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -41,8 +41,7 @@ public:
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
     int GetLogicalUly();
-    int GetLogicalLry();    
-    int m_facsScale = 1;
+    int GetLogicalLry();
 private:
 };
 

--- a/src/editortoolkit.cpp
+++ b/src/editortoolkit.cpp
@@ -361,7 +361,14 @@ bool EditorToolkit::Insert(std::string elementType, std::string staffId, int ulx
 
 
     if (elementType == "staff") {
-        Staff *newStaff = new Staff();
+        Object *parent = staff->GetParent();
+        assert(parent);
+        int n = parent->GetChildCount() + 1;
+        Staff *newStaff = new Staff(n);
+        newStaff->m_drawingStaffDef = staff->m_drawingStaffDef;
+        newStaff->m_drawingNotationType = staff->m_drawingNotationType;
+        newStaff->m_drawingLines = staff->m_drawingLines;
+        newStaff->m_drawingStaffSize = (uly - lry) / (newStaff->m_drawingLines - 1);
         zone->SetUlx(ulx);
         zone->SetUly(uly);
         zone->SetLrx(lrx);
@@ -371,9 +378,8 @@ bool EditorToolkit::Insert(std::string elementType, std::string staffId, int ulx
         surface->AddChild(zone);
         newStaff->SetZone(zone);
         newStaff->SetFacs(zone->GetUuid());
-        Layer *newlayer = new Layer();
-        Object *parent = staff->GetParent();
-        assert(parent);
+        Layer *newLayer = new Layer();
+        newStaff->AddChild(newLayer);
         parent->AddChild(newStaff);
         return true;
     }

--- a/src/editortoolkit.cpp
+++ b/src/editortoolkit.cpp
@@ -380,6 +380,22 @@ bool EditorToolkit::Insert(std::string elementType, std::string staffId, int ulx
         newStaff->SetFacs(zone->GetUuid());
         Layer *newLayer = new Layer();
         newStaff->AddChild(newLayer);
+
+        // Find index to insert new staff
+        ArrayOfObjects staves;
+        AttComparison ac(STAFF);
+        parent->FindAllChildByComparison(&staves, &ac);
+        staves.push_back(newStaff);
+        StaffSort staffSort;
+        std::stable_sort(staves.begin(), staves.end(), staffSort);
+        for (int i = 0; i < staves.size(); i++) {
+            if (staves.at(i) == newStaff) {
+                newStaff->SetParent(parent);
+                parent->InsertChild(newStaff, i);
+                return true;
+            }
+        }
+        LogMessage("Failed to insert newStaff into staff");
         parent->AddChild(newStaff);
         return true;
     }

--- a/src/facsimileinterface.cpp
+++ b/src/facsimileinterface.cpp
@@ -36,20 +36,20 @@ void FacsimileInterface::Reset()
 int FacsimileInterface::GetDrawingX() const
 {
     assert(m_zone);
-    return m_zone->GetUlx() * m_zone->m_facsScale;
+    return m_zone->GetUlx();
 }
 
 int FacsimileInterface::GetDrawingY() const
 {
     assert(m_zone);
-    int y = ( m_zone->GetLogicalUly()) * m_zone->m_facsScale;
+    int y = ( m_zone->GetLogicalUly());
     return y;
 }
 
 int FacsimileInterface::GetWidth() const
 {
     assert(m_zone);
-    return m_zone->m_facsScale * (m_zone->GetLrx() - m_zone->GetUlx());
+    return m_zone->GetLrx() - m_zone->GetUlx();
 }
 
 int FacsimileInterface::GetSurfaceY() const

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -939,15 +939,9 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
     dc->SetBrush(m_currentColour, AxSOLID);
 
     for (j = 0; j < staff->m_drawingLines; ++j) {
-        if (true) {
-            dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
-            // For drawing rectangles instead of lines
-            y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        }
-        else {
-            //dc->DrawLine(zone->m_facsScale * zone->GetUlx(), y, zone->m_facsScale * zone->GetLrx(), y);
-            y += m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        }
+        dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
+        // For drawing rectangles instead of lines
+        y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     }
 
     dc->ResetPen();


### PR DESCRIPTION
Support inserting a new staff through `vrv::EditorToolkit` and insert in-order (left-to-right, top-to-bottom) using the given zone.