### PR TITLE
Remove zones when orphaned by element

### DIFF
--- a/include/vrv/facsimileinterface.h
+++ b/include/vrv/facsimileinterface.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        facsimileinterface.h
-// Author:      Juliette Regimbal 
+// Author:      Juliette Regimbal
 // Created:     2018
 // Copyright (c) Authors and others. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
@@ -16,7 +16,7 @@ class Zone;
 class View;
 
 //----------------------------------------------------------------------------
-// FacsimileInterface 
+// FacsimileInterface
 //----------------------------------------------------------------------------
 
 class FacsimileInterface : public Interface, public AttFacsimile {
@@ -31,7 +31,7 @@ public:
     virtual void Reset();
     virtual InterfaceId IsInterface() { return INTERFACE_FACSIMILE; }
     ///@}
-    
+
     virtual int GetDrawingX() const;
     virtual int GetDrawingY() const;
 
@@ -39,18 +39,16 @@ public:
 
     /** Check if the object has a facsimile */
     bool HasFacsimile() { return this->HasFacs(); }
-   
+
     /** Set the zone */
-    ///@{
-    void SetZone(Zone *zone) { m_zone = zone; }
-    ///@}
-    
+    void SetZone(Zone *zone);
+
     int GetSurfaceY() const;
-    
+
     /** Get the zone */
     Zone *GetZone() { return m_zone; }
 private:
-    Zone *m_zone;
+    Zone *m_zone = nullptr;
 };
 }
 #endif

--- a/src/editortoolkit.cpp
+++ b/src/editortoolkit.cpp
@@ -1096,6 +1096,20 @@ bool EditorToolkit::Remove(std::string elementId)
     Object *parent = obj->GetParent();
     assert(parent);
     m_editInfo = elementId;
+    // Remove Zone for element (if any)
+    InterfaceComparison ic(INTERFACE_FACSIMILE);
+    ArrayOfObjects fiChildren;
+    obj->FindAllChildByComparison(&fiChildren, &ic);
+    FacsimileInterface *fi = dynamic_cast<FacsimileInterface *>(obj);
+    if (fi != nullptr && fi->HasFacs()) {
+        fi->SetZone(nullptr);
+    }
+    for (auto it = fiChildren.begin(); it != fiChildren.end(); ++it) {
+        fi = dynamic_cast<FacsimileInterface *>(*it);
+        if (fi != nullptr && fi->HasFacs()) {
+            fi->SetZone(nullptr);
+        }
+    }
     result = parent->DeleteChild(obj);
     if (isNeume && result) {
         if (!parent->Is(SYLLABLE)) {
@@ -1107,6 +1121,11 @@ bool EditorToolkit::Remove(std::string elementId)
             obj = parent;
             parent = parent->GetParent();
             if (parent == nullptr) { LogMessage("Null parent!"); return false; }
+            // Remove Zone for element (if any)
+            fi = dynamic_cast<FacsimileInterface *>(obj);
+            if (fi != nullptr && fi->HasFacs()) {
+                fi->SetZone(nullptr);
+            }
             result &= parent->DeleteChild(obj);
         }
     }

--- a/src/facsimileinterface.cpp
+++ b/src/facsimileinterface.cpp
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        facsimileinterface.cpp
-// Author:      Juliette Regimbal 
+// Author:      Juliette Regimbal
 // Created:     2018
 // Copyright (c) Authors and others. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
@@ -63,5 +63,16 @@ int FacsimileInterface::GetSurfaceY() const
     else {
         return surface->GetMaxY();
     }
+}
+
+void FacsimileInterface::SetZone(Zone *zone)
+{
+    if (m_zone != nullptr) {
+        Object *parent = m_zone->GetParent();
+        if (!parent->DeleteChild(m_zone)) {
+            printf("Failed to delete zone with ID %s\n", m_zone->GetUuid().c_str());
+        }
+    }
+    m_zone = zone;
 }
 }


### PR DESCRIPTION
This applies when setting a FascimileInterface to have a new zone. The
zone is set to `nullptr` for elements when `EditorToolkit::Remove` is
called. It applies to the element being removed and recursively for all
its children with a FacsimileInterface.

This addresses issue DDMAL/Neon2#321