### PR TITLE
Strict grouping

### DIFF
--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -9,6 +9,7 @@
 #define __VRV_SYL_H__
 
 #include "atts_shared.h"
+#include "facsimileinterface.h"
 #include "layerelement.h"
 #include "timeinterface.h"
 
@@ -29,6 +30,7 @@ class TextElement;
  */
 
 class Syl : public LayerElement,
+            public FacsimileInterface,
             public TextListInterface,
             public TimeSpanningInterface,
             public AttLang,
@@ -54,6 +56,7 @@ public:
      * @name Getter to interfaces
      */
     ///@{
+    virtual FacsimileInterface *GetFacsimileInterface() { return dynamic_cast<FacsimileInterface *>(this); }
     virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
     virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
@@ -70,6 +73,9 @@ public:
      * Called from Syl::AdjustSylSpacing and System::AdjustSylSpacingEnd
      */
     int CalcHorizontalAdjustment(int &overlap, AdjustSylSpacingParams *params);
+
+    virtual int GetDrawingX() const;
+    virtual int GetDrawingY() const;
 
     //----------//
     // Functors //

--- a/src/editortoolkit.cpp
+++ b/src/editortoolkit.cpp
@@ -1233,10 +1233,12 @@ bool EditorToolkit::Group(std::string groupType, std::vector<std::string> elemen
                 return false;
             }
         }
-        try {
-            parents.at(el->GetParent()) += 1;
-        } catch (const std::out_of_range e) {
+        auto possibleEntry = parents.find(el->GetParent());
+        if (possibleEntry == parents.end()) {
             parents.emplace(el->GetParent(), 1);
+        }
+        else {
+            possibleEntry->second += 1;
         }
         elements.insert(el);
     }

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -29,8 +29,9 @@ namespace vrv {
 // Syl
 //----------------------------------------------------------------------------
 
-Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
+Syl::Syl() : LayerElement("syl-"), FacsimileInterface(), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {
+    RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_TYPOGRAPHY);
@@ -44,6 +45,7 @@ Syl::~Syl() {}
 void Syl::Reset()
 {
     LayerElement::Reset();
+    FacsimileInterface::Reset();
     TimeSpanningInterface::Reset();
     ResetLang();
     ResetTypography();
@@ -118,6 +120,26 @@ int Syl::CalcHorizontalAdjustment(int &overlap, AdjustSylSpacingParams *params)
     }
 
     return nextFreeSpace;
+}
+
+int Syl::GetDrawingX() const
+{
+    if (this->HasFacs()) {
+        return FacsimileInterface::GetDrawingX();
+    }
+    else {
+        return LayerElement::GetDrawingX();
+    }
+}
+
+int Syl::GetDrawingY() const
+{
+    if (this->HasFacs()) {
+        return FacsimileInterface::GetDrawingY();
+    }
+    else {
+        return LayerElement::GetDrawingY();
+    }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This is meant to solve the issues described in DDMAL/Neon2#299. This checks that any group is empty before deleting it and will only make a new group if none of the parents of the elements listed are emptied through the grouping action (i.e. every child of the parent is listed to be grouped).

This also ensures that all elements have the same second parent. This means that if neume components are being grouped into a neume, they **must** be part of the same syllable, and likewise for grouping neumes they must be in the same staff. This is to avoid making assumptions (i.e. when grouping neume components in different syllables, which syllable (if either) should the new neume be in?).