### PR TITLE
Neon 350: text bounding box highlighting

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -81,6 +81,9 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
         const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
+    virtual void DrawBoundedText(
+        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, 
+        int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET);
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
     virtual void DrawSpline(int n, Point points[]);
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -80,10 +80,8 @@ public:
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle);
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
-        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
-    virtual void DrawBoundedText(
         const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, 
-        int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET);
+        int y = VRV_UNSET,  int width = VRV_UNSET, int heigh = VRV_UNSET);
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
     virtual void DrawSpline(int n, Point points[]);
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -148,6 +148,8 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius) = 0;
     virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET)
         = 0;
+    virtual void DrawBoundedText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET,
+        int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET) = 0;
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) = 0;
     virtual void DrawSpline(int n, Point points[]) = 0;
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -146,9 +146,7 @@ public:
     virtual void DrawRectangle(int x, int y, int width, int height) = 0;
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle) = 0;
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius) = 0;
-    virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET)
-        = 0;
-    virtual void DrawBoundedText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET,
+    virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET,
         int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET) = 0;
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) = 0;
     virtual void DrawSpline(int n, Point points[]) = 0;

--- a/include/vrv/facsimileinterface.h
+++ b/include/vrv/facsimileinterface.h
@@ -36,6 +36,7 @@ public:
     virtual int GetDrawingY() const;
 
     int GetWidth() const;
+    int GetHeight() const;
 
     /** Check if the object has a facsimile */
     bool HasFacsimile() { return this->HasFacs(); }

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -82,9 +82,7 @@ public:
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle);
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
-        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
-    virtual void DrawBoundedText(
-        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET,
+        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, 
         int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET);
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
     virtual void DrawSpline(int n, Point points[]);

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -83,6 +83,9 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
         const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
+    virtual void DrawBoundedText(
+        const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET,
+        int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET);
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
     virtual void DrawSpline(int n, Point points[]);
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -76,6 +76,8 @@ public:
 
     virtual int GetDrawingX() const;
     virtual int GetDrawingY() const;
+    virtual int GetDrawingWidth() const;
+    virtual int GetDrawingHeight() const;
 
     //----------//
     // Functors //

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -89,6 +89,7 @@ public:
         m_x = 0;
         m_y = 0;
         m_width = 0;
+        m_height = 0;
         m_laidOut = false;
         m_newLine = false;
         m_alignment = HORIZONTALALIGNMENT_left;
@@ -99,6 +100,7 @@ public:
     int m_x;
     int m_y;
     int m_width;
+    int m_height;
     bool m_laidOut;
     bool m_newLine;
     data_HORIZONTALALIGNMENT m_alignment;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -487,7 +487,7 @@ protected:
         wchar_t start = 0, wchar_t end = 0);
     void DrawSmuflString(DeviceContext *dc, int x, int y, std::wstring s, bool center, int staffSize = 100,
         bool dimin = false, bool setBBGlyph = false);
-    void DrawLyricString(DeviceContext *dc, int x, int y, std::wstring s, int staffSize = 100);
+    void DrawLyricString(DeviceContext *dc, TextDrawingParams &params, std::wstring s, int staffSize = 100);
     void DrawFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2);
     void DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2, int height);
     void DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width, bool fill, int linewidth);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -12,6 +12,7 @@
 #include "scoredef.h"
 #include "smufl.h"
 #include "vrvdef.h"
+#include "textelement.h"
 
 namespace vrv {
 

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -260,51 +260,46 @@ void BBoxDeviceContext::MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignm
     }
 }
 
-void BBoxDeviceContext::DrawText(const std::string &text, const std::wstring wtext, int x, int y)
+void BBoxDeviceContext::DrawText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height)
 {
     assert(m_fontStack.top());
 
-    if ((x != VRV_UNSET) && (y != VRV_UNSET)) {
-        m_textX = x;
-        m_textY = y;
-        m_textWidth = 0;
-        m_textHeight = 0;
-        m_textAscent = 0;
-        m_textDescent = 0;
-    }
-
-    TextExtend extend;
-    GetTextExtent(wtext, &extend, true);
-    m_textWidth += extend.m_width;
-    // keep that maximum values for ascent and descent
-    m_textAscent = std::max(m_textAscent, extend.m_ascent);
-    m_textDescent = std::max(m_textDescent, extend.m_descent);
-    m_textHeight = m_textAscent + m_textDescent;
-    if (m_textAlignment == HORIZONTALALIGNMENT_right) {
-        m_textX -= extend.m_width;
-    }
-    else if (m_textAlignment == HORIZONTALALIGNMENT_center) {
-        m_textX -= (extend.m_width / 2);
-    }
-    UpdateBB(m_textX, m_textY + m_textDescent, m_textX + m_textWidth, m_textY - m_textAscent);
-
-}
-
-//to draw text when the bounding box of the text is already defined
-//just use the defined coordinates instead of calculating them based on the contents of the string
-void BBoxDeviceContext::DrawBoundedText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height) {
-
-    assert(m_fontStack.top());
-
-    if((ulx != VRV_UNSET) && (uly != VRV_UNSET) && (lrx != VRV_UNSET) && (lry != VRV_UNSET)) {
+    if((x != VRV_UNSET) && (y != VRV_UNSET) && (width != VRV_UNSET) && (height != VRV_UNSET)) {
         m_textX = x;
         m_textY = y;
         m_textWidth = width;
         m_textHeight = height;
         m_textAscent = 0;
         m_textDescent = 0;
+        UpdateBB(m_textX, m_textY, m_textX + m_textWidth, m_textY + m_textHeight);
     }
-    UpdateBB(m_textX, m_textY, m_textX + m_textWidth, m_textY + m_textHeight);
+
+    else {
+        if ((x != VRV_UNSET) && (y != VRV_UNSET)) {
+            m_textX = x;
+            m_textY = y;
+            m_textWidth = 0;
+            m_textHeight = 0;
+            m_textAscent = 0;
+            m_textDescent = 0;
+        }
+
+        TextExtend extend;
+        GetTextExtent(wtext, &extend, true);
+        m_textWidth += extend.m_width;
+        // keep that maximum values for ascent and descent
+        m_textAscent = std::max(m_textAscent, extend.m_ascent);
+        m_textDescent = std::max(m_textDescent, extend.m_descent);
+        m_textHeight = m_textAscent + m_textDescent;
+        if (m_textAlignment == HORIZONTALALIGNMENT_right) {
+            m_textX -= extend.m_width;
+        }
+        else if (m_textAlignment == HORIZONTALALIGNMENT_center) {
+            m_textX -= (extend.m_width / 2);
+        }
+        UpdateBB(m_textX, m_textY + m_textDescent, m_textX + m_textWidth, m_textY - m_textAscent);
+    }
+    
 }
 
 void BBoxDeviceContext::DrawRotatedText(const std::string &text, int x, int y, double angle)

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -287,6 +287,24 @@ void BBoxDeviceContext::DrawText(const std::string &text, const std::wstring wte
         m_textX -= (extend.m_width / 2);
     }
     UpdateBB(m_textX, m_textY + m_textDescent, m_textX + m_textWidth, m_textY - m_textAscent);
+
+}
+
+//to draw text when the bounding box of the text is already defined
+//just use the defined coordinates instead of calculating them based on the contents of the string
+void BBoxDeviceContext::DrawBoundedText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height) {
+
+    assert(m_fontStack.top());
+
+    if((ulx != VRV_UNSET) && (uly != VRV_UNSET) && (lrx != VRV_UNSET) && (lry != VRV_UNSET)) {
+        m_textX = x;
+        m_textY = y;
+        m_textWidth = width;
+        m_textHeight = height;
+        m_textAscent = 0;
+        m_textDescent = 0;
+    }
+    UpdateBB(m_textX, m_textY, m_textX + m_textWidth, m_textY + m_textHeight);
 }
 
 void BBoxDeviceContext::DrawRotatedText(const std::string &text, int x, int y, double angle)

--- a/src/facsimileinterface.cpp
+++ b/src/facsimileinterface.cpp
@@ -55,7 +55,7 @@ int FacsimileInterface::GetWidth() const
 int FacsimileInterface::GetHeight() const
 { 
     assert(m_zone);
-    return m_zone->GetLogicalUly() - m_zone->GetLogicalLry();
+    return m_zone->GetLogicalLry() - m_zone->GetLogicalUly();
 }
 
 int FacsimileInterface::GetSurfaceY() const

--- a/src/facsimileinterface.cpp
+++ b/src/facsimileinterface.cpp
@@ -42,7 +42,7 @@ int FacsimileInterface::GetDrawingX() const
 int FacsimileInterface::GetDrawingY() const
 {
     assert(m_zone);
-    int y = ( m_zone->GetLogicalUly());
+    int y = (m_zone->GetLogicalUly());
     return y;
 }
 
@@ -50,6 +50,12 @@ int FacsimileInterface::GetWidth() const
 {
     assert(m_zone);
     return m_zone->GetLrx() - m_zone->GetUlx();
+}
+
+int FacsimileInterface::GetHeight() const
+{ 
+    assert(m_zone);
+    return m_zone->GetLogicalUly() - m_zone->GetLogicalLry();
 }
 
 int FacsimileInterface::GetSurfaceY() const

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4512,6 +4512,8 @@ bool MeiInput::ReadSyl(Object *parent, pugi::xml_node syl)
     vrvSyl->ReadTypography(syl);
     vrvSyl->ReadSylLog(syl);
 
+    ReadFacsimileInterface(syl, vrvSyl);
+
     parent->AddChild(vrvSyl);
     ReadUnsupportedAttr(syl, vrvSyl);
     return ReadTextChildren(vrvSyl, syl, vrvSyl);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -648,7 +648,7 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
         x -= width;
     }
 
-    pugi::xml_node rectChild = AppendChild("rect");
+    pugi::xml_node rectChild = AppendChild("sylTextRect");
     rectChild.append_attribute("x") = x;
     rectChild.append_attribute("y") = y;
     rectChild.append_attribute("height") = height;
@@ -776,7 +776,7 @@ void SvgDeviceContext::DrawText(const std::string &text, const std::wstring wtex
     if ((x != VRV_UNSET) && (y != VRV_UNSET) && (width != VRV_UNSET) && (height != VRV_UNSET)) {
         pugi::xml_node g = m_currentNode.parent().parent();
         pugi::xml_node rectChild = g.append_child("rect");
-        rectChild.append_attribute("class") = "rect";
+        rectChild.append_attribute("class") = "sylTextRect";
         rectChild.append_attribute("x") = StringFormat("%d", x).c_str();
         rectChild.append_attribute("y") = StringFormat("%d", y).c_str();
         rectChild.append_attribute("width") = StringFormat("%d", width).c_str();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -739,7 +739,9 @@ void SvgDeviceContext::DrawText(const std::string &text, const std::wstring wtex
     assert(m_fontStack.top());
 
     std::string svgText = text;
-
+    
+    // Because IE does not support xml:space="preserve", we need to replace the initial
+    // space with a non breakable space
     if ((svgText.length() > 0) && (svgText[0] == ' ')) {
         svgText.replace(0, 1, "\xC2\xA0");
     }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -771,6 +771,55 @@ void SvgDeviceContext::DrawText(const std::string &text, const std::wstring wtex
     }
 }
 
+//if the bounding box of the text is defined create a rectangle as a bounding box for the text
+void SvgDeviceContext::DrawBoundedText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height) {
+
+    assert(m_fontStack.top());
+
+    std::string svgText = text;
+
+    if ((svgText.length() > 0) && (svgText[0] == ' ')) {
+        svgText.replace(0, 1, "\xC2\xA0");
+    }
+    if ((svgText.length() > 0) && (svgText[svgText.size() - 1] == ' ')) {
+        svgText.replace(svgText.size() - 1, 1, "\xC2\xA0");
+    }
+
+    std::string currentFaceName
+        = (m_currentNode.attribute("font-family")) ? m_currentNode.attribute("font-family").value() : "";
+    std::string fontFaceName = m_fontStack.top()->GetFaceName();
+
+    pugi::xml_node textChild = AppendChild("tspan");
+    // We still add @xml::space (No: this seems to create problems with Safari)
+    // textChild.append_attribute("xml:space") = "preserve";
+    // Set the @font-family only if it is not the same as in the parent node
+    if (!fontFaceName.empty() && (fontFaceName != currentFaceName)) {
+        textChild.append_attribute("font-family") = m_fontStack.top()->GetFaceName().c_str();
+        // Special case where we want to specifiy if the VerovioText font (woff) needs to be included in the output
+        if (fontFaceName == "VerovioText") this->VrvTextFont();
+    }
+    if (m_fontStack.top()->GetPointSize() != 0) {
+        textChild.append_attribute("font-size") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();
+    }
+    textChild.append_attribute("class") = "text";
+    textChild.append_child(pugi::node_pcdata).set_value(svgText.c_str());
+
+    if ((x != VRV_UNSET) && (y != VRV_UNSET)) {
+        textChild.append_attribute("x") = StringFormat("%d", x).c_str();
+        textChild.append_attribute("y") = StringFormat("%d", y).c_str();
+    }
+
+    pugi::xml_node rectChild = AppendChild("rect");
+
+    rectChild.append_attribute("class") = "rect";
+    if ((ulx != VRV_UNSET) && (uly != VRV_UNSET) && (lrx != VRV_UNSET) && (lry != VRV_UNSET)) {
+        rectChild.append_attribute("x") = StringFormat("%d", x);
+        rectChild.append_attribute("y") = StringFormat("%d", y);
+        rectChild.append_attribute("width") = StringFormat("%d", width);
+        rectChild.append_attribute("height") = StringFormat("%d", height);
+    }
+}
+
 void SvgDeviceContext::DrawRotatedText(const std::string &text, int x, int y, double angle)
 {
     // TODO

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -36,7 +36,6 @@ Syl::Syl() : LayerElement("syl-"), FacsimileInterface(), TextListInterface(), Ti
     RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_TYPOGRAPHY);
     RegisterAttClass(ATT_SYLLOG);
-    RegisterAttClass(ATT_COORDINATED); //new
 
     Reset();
 }
@@ -141,6 +140,22 @@ int Syl::GetDrawingY() const
     else {
         return LayerElement::GetDrawingY();
     }
+}
+
+int Syl::GetDrawingWidth() const
+{
+    if(this->HasFacs()) {
+        return FacsimileInterface::GetWidth();
+    } 
+    return 0;
+}
+
+int Syl::GetDrawingHeight() const
+{
+    if(this->HasFacs()) {
+        return FacsimileInterface::GetHeight();
+    }
+    return 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -36,6 +36,7 @@ Syl::Syl() : LayerElement("syl-"), FacsimileInterface(), TextListInterface(), Ti
     RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_TYPOGRAPHY);
     RegisterAttClass(ATT_SYLLOG);
+    RegisterAttClass(ATT_COORDINATED); //new
 
     Reset();
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1369,6 +1369,8 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     TextDrawingParams params;
     params.m_x = syl->GetDrawingX();
     params.m_y = syl->GetDrawingY();
+    params.m_width = syl->GetDrawingWidth();
+    params.m_height = syl->GetDrawingHeight();
     assert(dc->GetFont());
     params.m_pointSize = dc->GetFont()->GetPointSize();
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1366,7 +1366,6 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     else {
         dc->SetFont(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize));
     }
-
     TextDrawingParams params;
     params.m_x = syl->GetDrawingX();
     params.m_y = syl->GetDrawingY();

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -263,10 +263,9 @@ void View::DrawLyricString(DeviceContext *dc, int x, int y, std::wstring s, int 
     std::wistringstream iss(s);
     std::wstring token;
     while (std::getline(iss, token, L'_')) {
-        dc->DrawText(UTF16to8(token), token);
+        dc->DrawText(UTF16to8(token), token, x, y);
         // no _
         if (iss.eof()) break;
-
         FontInfo vrvTxt;
         vrvTxt.SetFaceName("VerovioText");
         dc->SetFont(&vrvTxt);

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -256,14 +256,24 @@ void View::DrawSmuflString(
     dc->ResetBrush();
 }
 
-void View::DrawLyricString(DeviceContext *dc, int x, int y, std::wstring s, int staffSize)
+void View::DrawLyricString(DeviceContext *dc, TextDrawingParams &params, std::wstring s, int staffSize)
 {
     assert(dc);
 
     std::wistringstream iss(s);
     std::wstring token;
     while (std::getline(iss, token, L'_')) {
-        dc->DrawText(UTF16to8(token), token, x, y);
+        if ((params.m_x != VRV_UNSET) && (params.m_y != VRV_UNSET)) {
+            if ((params.m_width != VRV_UNSET) && (params.m_height != VRV_UNSET)) {
+                dc->DrawText(UTF16to8(token), token, params.m_x, params.m_y, params.m_width, params.m_height);
+            }
+            else {
+                dc->DrawText(UTF16to8(token), token, params.m_x, params.m_y);
+            }
+        }
+        else {
+            dc->DrawText(UTF16to8(token), token);
+        }
         // no _
         if (iss.eof()) break;
         FontInfo vrvTxt;
@@ -271,7 +281,17 @@ void View::DrawLyricString(DeviceContext *dc, int x, int y, std::wstring s, int 
         dc->SetFont(&vrvTxt);
         std::wstring str;
         str.push_back(VRV_TEXT_E551);
-        dc->DrawText(UTF16to8(str), str);
+        if ((params.m_x != VRV_UNSET) && (params.m_y != VRV_UNSET)) {
+            if ((params.m_width != VRV_UNSET) && (params.m_height != VRV_UNSET)) {
+                dc->DrawText(UTF16to8(token), token, params.m_x, params.m_y, params.m_width, params.m_height);
+            }
+            else {
+                dc->DrawText(UTF16to8(token), token, params.m_x, params.m_y);
+            }
+        }
+        else {
+            dc->DrawText(UTF16to8(token), token);
+        }
         dc->ResetFont();
     }
 }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -276,13 +276,14 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
     // special case where we want to replace the '_' with a lyric connector
     // '_' are produce with the SibMEI plugin
     else if (text->GetFirstParent(SYL)) {
-        DrawLyricString(dc, params.m_x, params.m_y, text->GetText());
+        DrawLyricString(dc, params, text->GetText());
     }
 
     else {
         if (params.m_laidOut && params.m_newLine) {
             dc->DrawText(
-                UTF16to8(text->GetText()), text->GetText(), ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y));
+                UTF16to8(text->GetText()), text->GetText(), ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y),
+                params.m_width, params.m_height);
             params.m_newLine = false;
         }
         else {


### PR DESCRIPTION
This resolves DDMAL/Neon2#350 

The DrawText methods now optionally accept height and width parameters, and when they are supplied appends a rect object to the syl object in the svg. The height and width parameters are passed whenever there is facsimile data for the syl's in the mei file.