### PR TITLE
Neon 358: syl facsimile io and behaviour

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1687,6 +1687,7 @@ void MeiOutput::WriteSyl(pugi::xml_node currentNode, Syl *syl)
     assert(syl);
 
     WriteLayerElement(currentNode, syl);
+    WriteFacsimileInterface(currentNode, syl);
     syl->WriteLang(currentNode);
     syl->WriteTypography(currentNode);
     syl->WriteSylLog(currentNode);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1498,6 +1498,7 @@ bool Object::sortByUlx(Object *a, Object *b)
         ArrayOfObjects children;
         a->FindAllChildByComparison(&children, &comp);
         for (auto it = children.begin(); it != children.end(); ++it) {
+            if((*it)->Is(SYL)) continue;
             FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*it);
             assert(temp);
             if (temp->HasFacs() && (fa == nullptr || temp->GetZone()->GetUlx() < fa->GetZone()->GetUlx())) {
@@ -1511,6 +1512,7 @@ bool Object::sortByUlx(Object *a, Object *b)
         ArrayOfObjects children;
         b->FindAllChildByComparison(&children, &comp);
         for (auto it = children.begin(); it != children.end(); ++it) {
+            if((*it)->Is(SYL)) continue;
             FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*it);
             assert(temp);
             if (temp->HasFacs() && (fb == nullptr || temp->GetZone()->GetUlx() < fb->GetZone()->GetUlx())) {


### PR DESCRIPTION
This resolve #DDMAL/Neon2#358 by ensuring that facsimile gets read/written by iomei.cpp and making sure that clefs are always placed before Syllable elements when writing to mei