### PR TITLE
Reorder staves on drag

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -464,6 +464,12 @@ public:
      */
     virtual int Save(FileOutputStream *output);
 
+    /**
+     * Sort the child elements using std::stable_sort
+     */
+    template <class Compare>
+    void StableSort(Compare comp) { std::stable_sort(m_children.begin(), m_children.end(), comp); }
+
     virtual void ReorderByXPos();
     /**
      * Main method that processes functors.

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -413,7 +413,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y, bool isChain)
             (*it)->ShiftByXY(x, -y);
         }
 
-        //TODO Reorder by left-to-right, top-to-bottom
+        staff->GetParent()->StableSort(StaffSort());
 
         return true; // Can't reorder by layer since staves contain layers
     }


### PR DESCRIPTION
Add `Object::StableSort` function that takes the comparison argument of `std::stable_sort` and sorts the children of the object. This is used to sort the staves whenever they are dragged, satisfying DDMAL/Neon#447.