### PR TITLE
fix oblique-related nc order when grouping ncs

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -2179,6 +2179,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
                 for (auto it = elements.begin(); it != elements.end(); ++it) {
                     if ((*it)->GetParent() != parent && !(*it)->Is(SYL)) {
                         (*it)->MoveItselfTo(parent);
+                        parent->ReorderByXPos();
                     }
                 }
                 doubleParent->AddChild(parent);


### PR DESCRIPTION
fix for Neon issue https://github.com/DDMAL/Neon/issues/792

Reordering for a parent is always needed when moving children.