### PR TITLE
🐛 Fix bounding box positioning on inserting neume action

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -835,16 +835,27 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             int draw_w = staff->GetWidth();
             int draw_h = staff->GetHeight();
             double theta = staff->GetDrawingRotate();
-            int x = ulx - staff->GetDrawingX();
-            int y = (int)( (draw_w - x) * tan(theta * PI / 180.0) );
-
             int staffUly = staff->GetDrawingY();
+            int x = ulx - staff->GetDrawingX();
+
             int bboxUlx = ulx;
-            int bboxUly = staffUly + draw_h - y;
-            int bboxWidth = 225; // width height and offset can be adjusted
+            int bboxUly;
+            // if staff rotates downward to the right
+            if (theta > 0) {
+                int y = (int)( (draw_w - x) * tan(theta * PI / 180.0) );
+                bboxUly = staffUly + draw_h - y;
+            } 
+            // if staff rotates upwards to the right 
+            else {
+                int y = (int)( x * tan(-theta * PI / 180.0) );
+                int h = (int)( draw_w * tan(-theta * PI / 180.0) );
+                bboxUly = staffUly + (draw_h - h) - y;
+            }
+            // width height and offset can be adjusted
+            int bboxWidth = 225;
             int bboxHeight = 175;
             int bboxOffsetX = 50;
-
+            
             sylZone->SetUlx(bboxUlx - bboxOffsetX);
             sylZone->SetUly(bboxUly);
             sylZone->SetLrx(bboxUlx + bboxWidth - bboxOffsetX);

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -831,7 +831,6 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             Zone *sylZone = new Zone();
 
             // calculate bboxUlx and bboxUly wrt rotation using sine rule
-            double PI = 3.14;
             int draw_w = staff->GetWidth();
             int draw_h = staff->GetHeight();
             double theta = staff->GetDrawingRotate();
@@ -842,13 +841,13 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             int bboxUly;
             // if staff rotates downward to the right
             if (theta > 0) {
-                int y = (int)( (draw_w - x) * tan(theta * PI / 180.0) );
+                int y = (int)( (draw_w - x) * tan(theta * M_PI / 180.0) );
                 bboxUly = staffUly + draw_h - y;
             } 
             // if staff rotates upwards to the right 
             else {
-                int y = (int)( x * tan(-theta * PI / 180.0) );
-                int h = (int)( draw_w * tan(-theta * PI / 180.0) );
+                int y = (int)( x * tan(-theta * M_PI / 180.0) );
+                int h = (int)( draw_w * tan(-theta * M_PI / 180.0) );
                 bboxUly = staffUly + (draw_h - h) - y;
             }
             // width height and offset can be adjusted

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -829,17 +829,17 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             Text *text = new Text();
             syl->AddChild(text);
             Zone *sylZone = new Zone();
-
-            // these constants are just to improve visibility of the default boundingbox
+            
+            int staffBottomY = staff->GetDrawingY() + staff->GetHeight();
             int offSetUlx = -50;
-            int offSetUly = 100;
+            int offSetUly = 0;
             int offSetLrx = 150;
-            int offSetLry = 250;
+            int offSetLry = 150;
 
             sylZone->SetUlx(ulx + offSetUlx);
-            sylZone->SetUly(uly + offSetUly);
+            sylZone->SetUly(staffBottomY + offSetUly);
             sylZone->SetLrx(ulx + offSetLrx);
-            sylZone->SetLry(uly + offSetLry);
+            sylZone->SetLry(staffBottomY + offSetLry);
             surface->AddChild(sylZone);
             fi->SetZone(sylZone);
         }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -829,17 +829,26 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             Text *text = new Text();
             syl->AddChild(text);
             Zone *sylZone = new Zone();
-            
-            int staffBottomY = staff->GetDrawingY() + staff->GetHeight();
-            int offSetUlx = -50;
-            int offSetUly = 0;
-            int offSetLrx = 150;
-            int offSetLry = 150;
 
-            sylZone->SetUlx(ulx + offSetUlx);
-            sylZone->SetUly(staffBottomY + offSetUly);
-            sylZone->SetLrx(ulx + offSetLrx);
-            sylZone->SetLry(staffBottomY + offSetLry);
+            // calculate bboxUlx and bboxUly wrt rotation using sine rule
+            double PI = 3.14;
+            int draw_w = staff->GetWidth();
+            int draw_h = staff->GetHeight();
+            double theta = staff->GetDrawingRotate();
+            int x = ulx - staff->GetDrawingX();
+            int y = (int)( (draw_w - x) * tan(theta * PI / 180.0) );
+
+            int staffUly = staff->GetDrawingY();
+            int bboxUlx = ulx;
+            int bboxUly = staffUly + draw_h - y;
+            int bboxWidth = 225; // width height and offset can be adjusted
+            int bboxHeight = 175;
+            int bboxOffsetX = 50;
+
+            sylZone->SetUlx(bboxUlx - bboxOffsetX);
+            sylZone->SetUly(bboxUly);
+            sylZone->SetLrx(bboxUlx + bboxWidth - bboxOffsetX);
+            sylZone->SetLry(bboxUly + bboxHeight);
             surface->AddChild(sylZone);
             fi->SetZone(sylZone);
         }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -831,9 +831,9 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             Zone *sylZone = new Zone();
 
             // these constants are just to improve visibility of the default boundingbox
-            int offSetUlx = 150;
-            int offSetUly = 50;
-            int offSetLrx = 350;
+            int offSetUlx = -50;
+            int offSetUly = 100;
+            int offSetLrx = 150;
             int offSetLry = 250;
 
             sylZone->SetUlx(ulx + offSetUlx);


### PR DESCRIPTION
Make it so bboxs appear directly under the staff when inserting neumes, taking into account staff rotation.

Fixes [Issue #647](https://github.com/DDMAL/Neon/issues/674). Parallel PR in Neon closes [#847](https://github.com/DDMAL/Neon/pull/847).