### PR TITLE
add moveOuttaSyllable button for layer elements

### DIFF
--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -42,6 +42,7 @@ public:
     bool Insert(std::string elementType, std::string staffId, int ulx, int uly, int lrx, int lry,
         std::vector<std::pair<std::string, std::string> > attributes);
     bool InsertToSyllable(std::string elementId);
+    bool MoveOuttaSyllable(std::string elementId);
     bool Merge(std::vector<std::string> elementIds);
     bool Set(std::string elementId, std::string attrType, std::string attrValue);
     bool SetText(std::string elementId, std::string text);
@@ -66,6 +67,7 @@ protected:
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *staffId, int *ulx, int *uly,
         int *lrx, int *lry, std::vector<std::pair<std::string, std::string> > *attributes);
     bool ParseInsertToSyllableAction(jsonxx::Object param, std::string *elementId);
+    bool ParseMoveOuttaSyllableAction(jsonxx::Object param, std::string *elementId);
     bool ParseMergeAction(jsonxx::Object param, std::vector<std::string> *elementIds);
     bool ParseSetAction(jsonxx::Object param, std::string *elementId, std::string *attrType, std::string *attrValue);
     bool ParseSetTextAction(jsonxx::Object param, std::string *elementId, std::string *text);


### PR DESCRIPTION
As requested in issue https://github.com/DDMAL/Neon/issues/841 and https://github.com/DDMAL/Neon/issues/762, added a button that can move divLine and accid out of a syllable if they are inside syllable. Will add this function to clef soon.