### PR TITLE
🐛 Fix divlines jumping to wrong staff lines.

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -3041,8 +3041,9 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
     ClosestBB comp;
 
     if (dynamic_cast<FacsimileInterface *>(element)->HasFacs()) {
-        comp.x = element->GetFacsimileInterface()->GetZone()->GetUlx();
-        comp.y = element->GetFacsimileInterface()->GetZone()->GetUly();
+        Zone* zone = element->GetFacsimileInterface()->GetZone();
+        comp.x = (zone->GetUlx() + zone->GetLrx()) / 2;
+        comp.y = (zone->GetUly() + zone->GetLry()) / 2;
     }
     else if (element->Is(SYLLABLE)) {
         int ulx, uly, lrx, lry;


### PR DESCRIPTION

So regarding Neon's # 863 and other Verovio changeStaff issues, from what I can tell, we identify the staff by sorting all staves and getting the nearest staff by coordinate.
But as Gen says as well, this isn't quite intuitive. An accidental and divline jumping up or down to another staff when it's moved even a little out of the staff is not great.
I was thinking why don't we send Verovio the staff's ID ourselves? We know the staff that the user moves a divline or accidental to, since we're hovering over one. If a divline or accidental is placed where there is no staff line, it will not change staff lines, and it'll stay in the staff line it was in.
You would also be able to give "staffId" as "auto", just like for other Verovio actions, for elements that you would like to be placed anywhere, even outside a staff, and that will just do the same code that we're doing currently.
(Also, if we're keeping our current closest-distance algorithm, we don't need to sort it. we could just go for some minimum function)
What do you think?