### PR TITLE
🐛 Fix "Insert to nearest syllable" not working for neumes with no neume components

### DIFF
--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -141,6 +141,8 @@ struct ClosestNeume {
 
     bool operator()(Object *a, Object *b)
     {
+        // check if neume has neume components
+        if (!a->GetFirst(NC) || !b->GetFirst(NC)) return true;
         if (!a->GetFirst(NC)->GetFacsimileInterface() || !b->GetFirst(NC)->GetFacsimileInterface()) return true;
         Zone *zoneA = a->GetFirst(NC)->GetFacsimileInterface()->GetZone();
         Zone *zoneB = b->GetFirst(NC)->GetFacsimileInterface()->GetZone();

--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -142,8 +142,22 @@ struct ClosestNeume {
     bool operator()(Object *a, Object *b)
     {
         // check if neume has neume components
-        if (!a->GetFirst(NC) || !b->GetFirst(NC)) return true;
-        if (!a->GetFirst(NC)->GetFacsimileInterface() || !b->GetFirst(NC)->GetFacsimileInterface()) return true;
+        if (!a->GetFirst(NC)) {
+            LogError("Neume %s doesn't have neume components.", a->GetUuid().c_str());
+            return true;
+        }
+        if(!b->GetFirst(NC)) {
+            LogError("Neume %s doesn't have neume components.", b->GetUuid().c_str());
+            return true;
+        }
+        if (!a->GetFirst(NC)->GetFacsimileInterface()) {
+            LogError("Neume component %s doesn't have facsimile.", a->GetFirst(NC)->GetUuid().c_str());
+            return true;
+        }
+        if (!b->GetFirst(NC)->GetFacsimileInterface()) {
+            LogError("Neume component %s doesn't have facsimile.", b->GetFirst(NC)->GetUuid().c_str());
+            return true;
+        }
         Zone *zoneA = a->GetFirst(NC)->GetFacsimileInterface()->GetZone();
         Zone *zoneB = b->GetFirst(NC)->GetFacsimileInterface()->GetZone();
 


### PR DESCRIPTION
Fixes https://github.com/DDMAL/Neon/issues/878 .

insertToSyllable() would cause an error because we rely on all neumes to have neume components, so when a neume exists on a staff that doesn't have a neume component, it freaks out.

Therefore, check in ClosestNeume if the neume component exists or not.