### PR TITLE
✨ Allow clefs to be inserted into nearest syllable

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -293,8 +293,12 @@ public:
 
     /**
      * Return the last child of the object (if any, NULL otherwise)
+     * GetLast returns the last element child of the specified type, if specified.
      */
+    ///@{
     Object *GetLast() const;
+    Object *GetLast(const ClassId classId = UNSPECIFIED);
+    ///@}
 
     /**
      * Get the parent of the Object
@@ -1221,6 +1225,7 @@ private:
      */
     ///@{
     ArrayOfObjects::iterator m_iteratorEnd, m_iteratorCurrent;
+    ArrayOfObjects::reverse_iterator m_reverse_iteratorEnd, m_reverse_iteratorCurrent;
     ClassId m_iteratorElementType;
     ///@}
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -422,6 +422,14 @@ Object *Object::GetLast() const
     return m_children.back();
 }
 
+Object *Object::GetLast(const ClassId classId)
+{
+    m_iteratorElementType = classId;
+    m_reverse_iteratorEnd = m_children.rend();
+    m_reverse_iteratorCurrent = std::find_if(m_children.rbegin(), m_reverse_iteratorEnd, ObjectComparison(m_iteratorElementType));
+    return (m_reverse_iteratorCurrent == m_reverse_iteratorEnd) ? NULL : *m_reverse_iteratorCurrent;
+}
+
 int Object::GetIdx() const
 {
     assert(m_parent);


### PR DESCRIPTION
In conjunction with [Neon PR#930](https://github.com/DDMAL/Neon/pull/930).

- [x]  Add pitch shifting logic for moveIntoSyllable
- [x] Add pitch shifting logic for moveOuttaSyllable
- [x] Account for inserted clef for Drag actions