### PR TITLE
Add an empty measure object only when none exist

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4501,7 +4501,8 @@ bool MEIInput::ReadSectionChildren(Object *parent, pugi::xml_node parentNode)
     }
 
     // New <measure> for blank files in neume notation
-    if (!unmeasured && parent->Is(SECTION) && (m_doc->m_notationType == NOTATIONTYPE_neume)) {
+    if (!unmeasured && parent->Is(SECTION) && (m_doc->m_notationType == NOTATIONTYPE_neume)
+        && !parent->FindDescendantByType(MEASURE)) {
         if (m_doc->IsNeumeLines()) {
             unmeasured = new Measure(NEUMELINE);
         }


### PR DESCRIPTION
* This will still break with facsimile since the measure has no corresponding zone