### PR TITLE
Fix closest staff finding and pitch alignment for new inserted element

### DIFF
--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -122,8 +122,8 @@ struct ClosestBB {
         int offset = (x - ulx) * tan(rotate * M_PI / 180.0);
         uly = uly + offset;
         lry = lry + offset;
-        int xDiff = std::abs(x - ulx);
-        int yDiff = std::abs(y - uly);
+        int xDiff = std::max((ulx > x ? ulx - x : 0), (x > lrx ? x - lrx : 0));
+        int yDiff = std::max((uly > y ? uly - y : 0), (y > lry ? y - lry : 0));
 
         return sqrt(xDiff * xDiff + yDiff * yDiff);
     }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -1250,6 +1250,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
     }
     layer->ReorderByXPos();
 
+    m_doc->GetDrawingPage()->LayOutPitchPos();
     if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
     m_editInfo.import("status", status);


### PR DESCRIPTION
- Revert changes in `ClosestBB::distanceToBB()`
- Call `Page::LayOutPitchPos()` after adjust pitch

Refs: https://github.com/DDMAL/Neon/issues/1226